### PR TITLE
feat: make detailed_response configurable for calendar events list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scoro-api-v2-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scoro-api-v2-sdk",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "ISC",
       "dependencies": {
         "fetch": "^1.1.0"

--- a/src/resources/base.ts
+++ b/src/resources/base.ts
@@ -70,7 +70,8 @@ export abstract class APIClient {
     filters: Record<string, any> = {},
     request: Record<string, any> = {},
     perPage = 50,
-    page = 1
+    page = 1,
+    detailedResponse = true
   ): Promise<T[]> {
     const body = {
       ...this.payload,
@@ -78,7 +79,7 @@ export abstract class APIClient {
       filter: filters,
       per_page: perPage,
       page: page,
-      detailed_response: true,
+      detailed_response: detailedResponse,
     }
 
     const response = await fetch(`${this.siteUrl}/api/v2/${endpoint}/list`, {

--- a/src/resources/services/calendar/calendar.service.ts
+++ b/src/resources/services/calendar/calendar.service.ts
@@ -9,9 +9,17 @@ export class CalendarService extends APIClient {
   async findAllCalendarEventsBy(
     filters: Record<string, any>,
     perPage = 50,
-    page = 1
+    page = 1,
+    detailedResponse = true
   ): Promise<ICalendar[]> {
-    return await this.list<ICalendar>('calendar', filters, {}, perPage, page)
+    return await this.list<ICalendar>(
+      'calendar',
+      filters,
+      {},
+      perPage,
+      page,
+      detailedResponse
+    )
   }
 
   async getCalendarById(id: number): Promise<ICalendar> {


### PR DESCRIPTION
findAllCalendarEventsBy will support detailed response flag. Setting it to false will allow to increase perPage value to 100