### PR TITLE
Calendar events batch upsert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scoro-api-v2-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scoro-api-v2-sdk",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "ISC",
       "dependencies": {
         "fetch": "^1.1.0"

--- a/src/resources/base.ts
+++ b/src/resources/base.ts
@@ -70,7 +70,8 @@ export abstract class APIClient {
     filters: Record<string, any> = {},
     request: Record<string, any> = {},
     perPage = 50,
-    page = 1
+    page = 1,
+    detailedResponse = true
   ): Promise<T[]> {
     const body = {
       ...this.payload,
@@ -78,7 +79,7 @@ export abstract class APIClient {
       filter: filters,
       per_page: perPage,
       page: page,
-      detailed_response: true,
+      detailed_response: detailedResponse,
     }
 
     const response = await fetch(`${this.siteUrl}/api/v2/${endpoint}/list`, {

--- a/src/resources/services/calendar/calendar.service.ts
+++ b/src/resources/services/calendar/calendar.service.ts
@@ -1,5 +1,6 @@
 import { APIClient } from '@/resources/base'
 import { ICalendar } from './types/calendar.type'
+import { IBatchResponseData } from '@/resources/types/response.type'
 
 export class CalendarService extends APIClient {
   async getCalendarEvents(): Promise<ICalendar[]> {
@@ -35,6 +36,12 @@ export class CalendarService extends APIClient {
     data: Partial<ICalendar>
   ): Promise<ICalendar> {
     return await this.update<ICalendar>('calendar', id, data)
+  }
+
+  async batchUpsertCalendar(
+    data: Partial<ICalendar>[]
+  ): Promise<IBatchResponseData<ICalendar>[]> {
+    return await this.batch<ICalendar>('calendar', data)
   }
 
   async deleteCalendar(id: number): Promise<void> {

--- a/src/resources/services/calendar/calendar.service.ts
+++ b/src/resources/services/calendar/calendar.service.ts
@@ -9,9 +9,17 @@ export class CalendarService extends APIClient {
   async findAllCalendarEventsBy(
     filters: Record<string, any>,
     perPage = 50,
-    page = 1
+    page = 1,
+    detailedResponse = true
   ): Promise<ICalendar[]> {
-    return await this.list<ICalendar>('calendar', filters, {}, perPage, page)
+    return await this.list<ICalendar>(
+      'calendar',
+      filters,
+      {},
+      perPage,
+      page,
+      detailedResponse
+    )
   }
 
   async getCalendarById(id: number): Promise<ICalendar> {

--- a/src/resources/services/calendar/types/calendar.type.ts
+++ b/src/resources/services/calendar/types/calendar.type.ts
@@ -1,6 +1,7 @@
 import { IEventResource } from '@/services/event-resource/types/events-resorces.types'
 import { IEvent } from '@/resources/services/shared/types/event.type'
 import { IUser } from '@/services/user/types/user.type'
+import { IExternalData } from '@/services/calendar/types/external-data.type'
 
 export interface ICalendar extends IEvent {
   address: string
@@ -19,6 +20,8 @@ export interface ICalendar extends IEvent {
       }[]
     | string // Array of guests linked to calendar event, not filterable
   call_link?: string // Conference call link attached to calendar event, not filterable
+  repeat_id?: number // ID of the parent event in case of a repeated event
+  external_data?: IExternalData // External data, not filterable
   activity_id?: number
   activity_type?: string // Activity type, not filterable
   project_phase_id?: number

--- a/src/resources/services/calendar/types/external-data.type.ts
+++ b/src/resources/services/calendar/types/external-data.type.ts
@@ -1,0 +1,8 @@
+export interface IExternalData {
+  external_id?: string
+  external_system?: string
+  external_modified_date?: string // Datetime format (DATE_ISO8601 - Y-m-d\TH:i:sP)
+  uid?: string
+  is_up_to_date?: boolean
+  external_guests?: string[] // Array of external guests linked to calendar event
+}

--- a/src/resources/types/response.type.ts
+++ b/src/resources/types/response.type.ts
@@ -15,3 +15,17 @@ export interface IListResponse<T> {
   errors: Record<string, string>
   data: T[]
 }
+
+export interface IBatchResponseData<T> {
+  object: T
+  action: string
+  errors: string[]
+}
+
+export interface IBatchResponse<T> {
+  status: string
+  statusCode: number
+  messages: Record<string, string>
+  errors: Record<string, string>
+  data: IBatchResponseData<T>[] | null
+}


### PR DESCRIPTION
Possible to send up to 50 events with 1 request to create or update.
Update is possible by using event_id or external_data. When using external data, external_id and external_system or uid can be used to identify existing event.