### PR TITLE
feat: add external repeating event id and uid to external data for recurring events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scoro-api-v2-sdk",
-  "version": "1.6.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scoro-api-v2-sdk",
-      "version": "1.6.0",
+      "version": "1.9.0",
       "license": "ISC",
       "dependencies": {
         "fetch": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scoro-api-v2-sdk",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A simple SDK to interact with Scoro API v2",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/resources/services/calendar/types/calendar.type.ts
+++ b/src/resources/services/calendar/types/calendar.type.ts
@@ -10,7 +10,7 @@ export interface ICalendar extends IEvent {
   full_day_event: boolean
   status: 'busy' | 'free' | 'tentative' | 'outofoffice' | string
   status_name?: string // Available in view request
-  cal_user?: IUser[] // Users related with this event, populated only on view requests. For modify requests it takes an array of user IDs
+  cal_user?: IUser[] | number[] // Users related with this event, populated only on view requests. For modify requests it takes an array of user IDs
   resources?: IEventResource[] // Array of resources related to calendar event, populated only on view requests
   related_task_id?: number // Related Task ID, used when calendar event is related to a task
   guests?:

--- a/src/resources/services/calendar/types/external-data.type.ts
+++ b/src/resources/services/calendar/types/external-data.type.ts
@@ -5,4 +5,6 @@ export interface IExternalData {
   uid?: string
   is_up_to_date?: boolean
   external_guests?: string[] // Array of external guests linked to calendar event
+  external_repeat_id?: string // ID of the parent event in case of a repeated event
+  external_repeat_uid?: string // UID of the parent event in case of a repeated event
 }

--- a/src/resources/services/user/types/user.type.ts
+++ b/src/resources/services/user/types/user.type.ts
@@ -4,6 +4,7 @@ export interface IUser {
   firstname: string
   lastname: string
   full_name: string
+  name?: string // Field for full name in some list responses with detailedResponse = false
   initials: string
   email: string
   is_active?: boolean // Deprecated


### PR DESCRIPTION
feat: External recurring events can be grouped  together using external_repeat_id and uid in external_data
fix: ICalendar cal_user should be number[] for modify request