### PR TITLE
feat: add external_meta_data to IExternalData

### DIFF
--- a/src/resources/services/calendar/types/external-data.type.ts
+++ b/src/resources/services/calendar/types/external-data.type.ts
@@ -7,4 +7,5 @@ export interface IExternalData {
   external_guests?: string[] // Array of external guests linked to calendar event
   external_repeat_id?: string // ID of the parent event in case of a repeated event
   external_repeat_uid?: string // UID of the parent event in case of a repeated event
+  external_meta_data?: unknown[] // External meta data, not filterable
 }


### PR DESCRIPTION
Add external meta data support for IExternalData. An array of external data to include to the event